### PR TITLE
Fixup for Windows DLL Loading

### DIFF
--- a/bench/Alice/Alice.csproj
+++ b/bench/Alice/Alice.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IronRure/IronRure.csproj
+++ b/src/IronRure/IronRure.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net47</TargetFrameworks>
     <Version>0.9.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IronRure.Batteries-Darwin" Version="2.6.0" />
-    <PackageReference Include="IronRure.Batteries-Windows" Version="2.6.0" />
+    <PackageReference Include="IronRure.Batteries-Windows" Version="2.6.1" />
     <PackageReference Include="IronRure.Batteries-Linux" Version="2.6.0" />
   </ItemGroup>
 </Project>

--- a/src/IronRure/IronRure.csproj
+++ b/src/IronRure/IronRure.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <Version>0.9.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/src/IronRure/RureFfi.cs
+++ b/src/IronRure/RureFfi.cs
@@ -5,6 +5,24 @@ namespace IronRure
 {
     public static class RureFfi
     {
+#if NET45
+        using System.Io;
+        
+        static RureFfi()
+        {
+            var currentLocation = new Uri(typeof(RureFfi).Assembly.CodeBase).LocalPath;
+
+            LoadLibrary(Path.Combine(
+                Path.GetDirectoryName(currentLocation),
+                Environment.Is64Bitprocess() ? "rure_x64" : "rure_x86",
+                "rure.dll"
+            ));
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr LoadLibrary(string dllToLoad);
+#endif
+
         /// <summary>
         ///   rure_compile compiles the given pattern into a regular expression. The
         ///   pattern must be valid UTF-8 and the length corresponds to the number of

--- a/src/IronRure/RureFfi.cs
+++ b/src/IronRure/RureFfi.cs
@@ -1,20 +1,19 @@
 using System;
 using System.Runtime.InteropServices;
+using System.IO;
 
 namespace IronRure
 {
     public static class RureFfi
     {
-#if NET45
-        using System.Io;
-        
+#if NET47
         static RureFfi()
         {
             var currentLocation = new Uri(typeof(RureFfi).Assembly.CodeBase).LocalPath;
 
             LoadLibrary(Path.Combine(
                 Path.GetDirectoryName(currentLocation),
-                Environment.Is64Bitprocess() ? "rure_x64" : "rure_x86",
+                Environment.Is64BitProcess ? "rure_x64" : "rure_x86",
                 "rure.dll"
             ));
         }

--- a/test/IronRureTests/IronRureTests.csproj
+++ b/test/IronRureTests/IronRureTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Updates the way that DLLs are loaded on Windows .NET Framework builds. The idea
is that by manually loading the library before P/Invoke gets involved we can have
"Any CPU" builds back.