### PR TITLE
Update Package References to New 1.0.5 Package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '1.0.{build}'
+skip_branch_with_pr: true
 image: Visual Studio 2017
 install:
   - dotnet --version

--- a/src/IronRure/IronRure.csproj
+++ b/src/IronRure/IronRure.csproj
@@ -9,11 +9,11 @@
     </Description>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="IronRure.Batteries-Darwin" Version="100.0.1" />
-    <PackageReference Include="IronRure.Batteries-Linux" Version="100.0.1" />
+    <PackageReference Include="IronRure.Batteries-Darwin" Version="100.5.0" />
+    <PackageReference Include="IronRure.Batteries-Linux" Version="100.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IronRure.Batteries-Windows" Version="100.0.1" >
+    <PackageReference Include="IronRure.Batteries-Windows" Version="100.5.0" >
 	  <PrivateAssets>none</PrivateAssets>
 	</PackageReference>
   </ItemGroup>

--- a/src/IronRure/IronRure.csproj
+++ b/src/IronRure/IronRure.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net45</TargetFrameworks>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <Author>Will Speak (@iwillspeak)</Author>
     <Description>
       Bindings to the Rust `regex` crate from .NET.


### PR DESCRIPTION
This won't work right now as the packages aren't published to NuGet.

TODO: 

 * [x] Push battery packages to NuGet
 * [x] Push new build of IronRure to NuGet