### PR TITLE
Fix .NET Framework Load Failures

### DIFF
--- a/ci_build.ps1
+++ b/ci_build.ps1
@@ -18,7 +18,7 @@ Test-LastExitCode $lastexitcode
 
 
 
-if (${env:APPVEYOR_REPO_TAG})
+if (${env:APPVEYOR_REPO_TAG} -eq $true)
 {
     dotnet pack --no-restore `
         -o artifacts_nuget `

--- a/src/IronRure/RureFfi.cs
+++ b/src/IronRure/RureFfi.cs
@@ -8,12 +8,26 @@ namespace IronRure
     public static class RureFfi
     {
 #if NET45
+        private static bool TryLoadFrom(string basePath)
+        {
+            var location = Path.Combine(
+                basePath,
+                Environment.Is64BitProcess ? "rure_x64" : "rure_x86",
+                "rure.dll");
+
+            if (Path.Exists(location))
+            {
+                var hmod = LoadLibrary(location);
+                return hmod != IntPtr.Zero;
+            }
+            return false;
+        }
+
         static RureFfi()
         {
-            LoadLibrary(Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                Environment.Is64BitProcess ? "rure_x64" : "rure_x86",
-                "rure.dll"
-            ));
+            var currentLocation = new Uri(typeof(RureFfi).Assembly.CodeBase).LocalPath;
+            TryLoadFrom(Path.GetDirectoryName(currentLocation)) ||
+                TryLoadFrom(Appdomain.CurrentDomain.BaseDirectory);
         }
 
         [DllImport("kernel32.dll")]

--- a/src/IronRure/RureFfi.cs
+++ b/src/IronRure/RureFfi.cs
@@ -22,8 +22,10 @@ namespace IronRure
         static RureFfi()
         {
             var currentLocation = new Uri(typeof(RureFfi).Assembly.CodeBase).LocalPath;
-            TryLoadFrom(Path.GetDirectoryName(currentLocation)) ||
+            if (!TryLoadFrom(Path.GetDirectoryName(currentLocation)))
+            {
                 TryLoadFrom(AppDomain.CurrentDomain.BaseDirectory);
+            }
         }
 
         [DllImport("kernel32.dll")]

--- a/src/IronRure/RureFfi.cs
+++ b/src/IronRure/RureFfi.cs
@@ -15,19 +15,15 @@ namespace IronRure
                 Environment.Is64BitProcess ? "rure_x64" : "rure_x86",
                 "rure.dll");
 
-            if (Path.Exists(location))
-            {
-                var hmod = LoadLibrary(location);
-                return hmod != IntPtr.Zero;
-            }
-            return false;
+            var hmod = LoadLibrary(location);
+            return hmod != IntPtr.Zero;
         }
 
         static RureFfi()
         {
             var currentLocation = new Uri(typeof(RureFfi).Assembly.CodeBase).LocalPath;
             TryLoadFrom(Path.GetDirectoryName(currentLocation)) ||
-                TryLoadFrom(Appdomain.CurrentDomain.BaseDirectory);
+                TryLoadFrom(AppDomain.CurrentDomain.BaseDirectory);
         }
 
         [DllImport("kernel32.dll")]


### PR DESCRIPTION
Fix for when the app domain base directory isn't the output
directory. This is the case when running under IIS.

Fix for #33 